### PR TITLE
Fixing an issue with sha256 checking

### DIFF
--- a/pushshift/pushshift_to_sqlite.py
+++ b/pushshift/pushshift_to_sqlite.py
@@ -48,7 +48,7 @@ def reddit_processing(url, sha256sums, dumps_directory, keep_dumps):
         return True
 
     try:
-        download_file(url, dump_file_path, sha256sums.get(base_name))
+        download_file(url, sha256sums.get(base_name), dump_file_path)
     except Exception as ex:
         logger.info(f"Download failed {ex}, skipping processing.")
         return False

--- a/utils/archive_stream_readers.py
+++ b/utils/archive_stream_readers.py
@@ -29,7 +29,7 @@ def get_archive_stream_reader(file_path):
     extension = file_path.split(".")[-1]
 
     if extension == "zst":
-        return ArchiveStreamReader(file_path, zstd.ZstdDecompressor().stream_reader)
+        return ArchiveStreamReader(file_path, zstd.ZstdDecompressor(max_window_size=2147483648).stream_reader)
     elif extension == "bz2":
         return ArchiveStreamReader(file_path, bz2.BZ2File)
     elif extension == "xz":


### PR DESCRIPTION
The pushshift.pushshift_to_sqlite method passes the arguments to best_download.download_file  in a wrong order, and the code crashes. Hence, the dataset is not reproducible without this modification. 